### PR TITLE
fix type inconsistency

### DIFF
--- a/src/internal.js
+++ b/src/internal.js
@@ -634,7 +634,8 @@ function registerRowEvents(tbody)
                 e.stopPropagation();
 
                 var $this = $(this),
-                    id = that.converter.from($this.val());
+                    id = (that.identifier == null) ? +$this.parents("tr").data("row-id") : 
+                        that.converter.from($this.parents("tr").data("row-id"));
 
                 if ($this.prop("checked"))
                 {


### PR DESCRIPTION
This commit fixed type consistency between value of checkbox and the data `row-id' of the row.

If the identifier is { id: "12"} , checkbox value will be the exact string "12" while the data `row-id' ( converted from the type) will be integer 12. When rowSelect is true and user performs rowSelect, the selectedrows will be [12], however, if he/she uses selectbox, the selectedrows will be ["12"]. This type consistency will mess up all logic of deciding selected rows.

How can one trigger this bug?

set rowSelect and multiSelect be true.
and let data be [{id: "1"}, {id: "2"}].

rowSelect row 1 then unselect using checkbox, then rowSelect row 2 and one can see both row 1 and row 2 are selected.
