### PR TITLE
Bug fix for prev and next links issue

### DIFF
--- a/build/jquery.bootgrid.js
+++ b/build/jquery.bootgrid.js
@@ -493,9 +493,9 @@
                     {
                         var commandList = {
                             first: 1,
-                            prev: that.current - 1,
-                            next: that.current + 1,
-                            last: that.totalPages
+                            prev: parseInt(that.current) - 1,
+                            next: parseInt(that.current) + 1,
+                            last: parseInt(that.totalPages)
                         };
                         var command = $this.attr("href").substr(1);
                         that.current = commandList[command] || +command; // + converts string to int


### PR DESCRIPTION
Somehow the current number is being concatenated with + 1 resulting in:  1 + 1 (11). So I have wrapped the numbers with parseInt to make sure we are getting integers. This fixed my issue.