### PR TITLE
bootgrid checkbox rowSelection is not working [364]

### DIFF
--- a/src/internal.js
+++ b/src/internal.js
@@ -649,7 +649,7 @@ function registerRowEvents(tbody)
     var that = this,
         selectBoxSelector = getCssSelector(this.options.css.selectBox);
 
-    if (this.selection)
+    if (this.selection && !this.options.rowSelect)
     {
         tbody.off("click" + namespace, selectBoxSelector)
             .on("click" + namespace, selectBoxSelector, function(e)


### PR DESCRIPTION
fix for https://github.com/rstaib/jquery-bootgrid/issues/364, when rowselect is enabled the click event is triggered twice.
Exclude row toggle event on checkbox click should prevent this from happening, which still leaves a small style issue in there if rowSelect and multiselect are both disabled.
